### PR TITLE
Fix blog 404s and Chakra v3 icon button regressions

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -36,7 +36,7 @@ const Footer = () => {
               size="sm"
               variant="ghost"
               aria-label="Twitter"
-              color={useColorModeValue("neutral.800", "neutralD.1000")}
+              color={useColorModeValue("neutral.1000", "neutralD.1000")}
             >
               <TwitterLogo weight="fill" />
             </IconButton>
@@ -46,7 +46,7 @@ const Footer = () => {
               size="sm"
               variant="ghost"
               aria-label="LinkedIn"
-              color={useColorModeValue("neutral.800", "neutralD.1000")}
+              color={useColorModeValue("neutral.1000", "neutralD.1000")}
             >
               <LinkedinLogo weight="fill" />
             </IconButton>
@@ -56,7 +56,7 @@ const Footer = () => {
               size="sm"
               variant="ghost"
               aria-label="GitHub"
-              color={useColorModeValue("neutral.800", "neutralD.1000")}
+              color={useColorModeValue("neutral.1000", "neutralD.1000")}
             >
               <GithubLogo weight="fill" />
             </IconButton>
@@ -66,7 +66,7 @@ const Footer = () => {
               size="sm"
               variant="ghost"
               aria-label="YouTube"
-              color={useColorModeValue("neutral.800", "neutralD.1000")}
+              color={useColorModeValue("neutral.1000", "neutralD.1000")}
             >
               <YoutubeLogo weight="fill" />
             </IconButton>

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -34,6 +34,7 @@ const Footer = () => {
           <Link href="https://twitter.com/wirtzdan/" isExternal unstyled>
             <IconButton
               size="sm"
+              variant="ghost"
               aria-label="Twitter"
               color={useColorModeValue("neutral.800", "neutralD.1000")}
             >
@@ -43,6 +44,7 @@ const Footer = () => {
           <Link href="https://www.linkedin.com/in/wirtzdan/" isExternal unstyled>
             <IconButton
               size="sm"
+              variant="ghost"
               aria-label="LinkedIn"
               color={useColorModeValue("neutral.800", "neutralD.1000")}
             >
@@ -52,6 +54,7 @@ const Footer = () => {
           <Link href="https://github.com/wirtzdan" isExternal unstyled>
             <IconButton
               size="sm"
+              variant="ghost"
               aria-label="GitHub"
               color={useColorModeValue("neutral.800", "neutralD.1000")}
             >
@@ -61,6 +64,7 @@ const Footer = () => {
           <Link href="https://www.youtube.com/channel/UCje_bQMr6F45x0Auii7IOvA" isExternal unstyled>
             <IconButton
               size="sm"
+              variant="ghost"
               aria-label="YouTube"
               color={useColorModeValue("neutral.800", "neutralD.1000")}
             >

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -98,17 +98,19 @@ const Header = () => {
               >
                 <Menu.Trigger asChild>
                   <Button
+                    variant="ghost"
                     onMouseOver={onOpen}
                     onClick={open ? onClose : onOpen}
                     onMouseLeave={delayedClose}
                     onMouseEnter={cancelDelayedClose}
                     cursor="default"
-                    bg={menuBg}
+                    color={useColorModeValue("neutral.1100", "neutralD.1100")}
+                    bg="transparent"
                     _hover={{ bg: menuButtonHoverBg }}
                     _active={{ bg: menuButtonHoverBg }}
                   >
                     Lists
-                    <Icon asChild>
+                    <Icon boxSize={5} asChild>
                       <ChevronDownIcon />
                     </Icon>
                   </Button>

--- a/components/mobile-menu-button.tsx
+++ b/components/mobile-menu-button.tsx
@@ -1,7 +1,9 @@
 "use client";
-import { Icon, Text, VStack, type StackProps } from "@chakra-ui/react";
+import { Box, Text, VStack, type StackProps } from "@chakra-ui/react";
 import { useColorModeValue } from "./ui/color-mode";
-import type { ReactElement } from "react";
+import { cloneElement, isValidElement, type ReactElement } from "react";
+
+const ICON_SIZE_PX = 20;
 
 interface MobileMenuButtonProps extends StackProps {
   label: string;
@@ -9,6 +11,21 @@ interface MobileMenuButtonProps extends StackProps {
 }
 
 const MobileMenuButton = ({ label, icon, ...rest }: MobileMenuButtonProps) => {
+  // Force explicit SVG dimensions. Chakra Icon asChild + Heroicons was leaving the
+  // theme moon/sun at ~2× the Blog/Menu icons and overflowing the mobile nav bar.
+  const sizedIcon = isValidElement(icon)
+    ? cloneElement(icon as ReactElement<Record<string, unknown>>, {
+        width: ICON_SIZE_PX,
+        height: ICON_SIZE_PX,
+        style: {
+          width: ICON_SIZE_PX,
+          height: ICON_SIZE_PX,
+          display: "block",
+          flexShrink: 0,
+        },
+      })
+    : icon;
+
   return (
     <VStack
       as="button"
@@ -18,9 +35,17 @@ const MobileMenuButton = ({ label, icon, ...rest }: MobileMenuButtonProps) => {
       {...rest}
       color={useColorModeValue("neutral.1100", "neutralD.1100")}
     >
-      <Icon boxSize={5} asChild>
-        {icon}
-      </Icon>
+      <Box
+        boxSize={`${ICON_SIZE_PX}px`}
+        flexShrink={0}
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        overflow="hidden"
+        lineHeight={0}
+      >
+        {sizedIcon}
+      </Box>
 
       <Text
         fontSize="xs"

--- a/components/mobile-menu-button.tsx
+++ b/components/mobile-menu-button.tsx
@@ -18,7 +18,9 @@ const MobileMenuButton = ({ label, icon, ...rest }: MobileMenuButtonProps) => {
       {...rest}
       color={useColorModeValue("neutral.1100", "neutralD.1100")}
     >
-      <Icon as={() => icon} boxSize={5} />
+      <Icon boxSize={5} asChild>
+        {icon}
+      </Icon>
 
       <Text
         fontSize="xs"

--- a/components/mobile-menu-toggle.tsx
+++ b/components/mobile-menu-toggle.tsx
@@ -32,7 +32,11 @@ const MobileMenuToggle = ({ mobile }: MobileMenuToggleProps) => {
   return (
     <Box>
       <Tooltip content="Newsletter">
-        <MobileMenuButton label="Menu" icon={<Bars3Icon />} onClick={onOpen} />
+        <MobileMenuButton
+          label="Menu"
+          icon={<Bars3Icon width={20} height={20} />}
+          onClick={onOpen}
+        />
       </Tooltip>
       <Drawer.Root
         open={open}
@@ -74,7 +78,7 @@ const MobileMenuToggle = ({ mobile }: MobileMenuToggleProps) => {
                             aria-label="Twitter"
                             size="sm"
                             variant="ghost"
-                            color={useColorModeValue("neutral.800", "neutralD.1000")}
+                            color={useColorModeValue("neutral.1000", "neutralD.1000")}
                           >
                             <TwitterLogo weight="fill" />
                           </IconButton>
@@ -84,7 +88,7 @@ const MobileMenuToggle = ({ mobile }: MobileMenuToggleProps) => {
                             aria-label="LinkedIn"
                             size="sm"
                             variant="ghost"
-                            color={useColorModeValue("neutral.800", "neutralD.1000")}
+                            color={useColorModeValue("neutral.1000", "neutralD.1000")}
                           >
                             <LinkedinLogo weight="fill" />
                           </IconButton>
@@ -94,7 +98,7 @@ const MobileMenuToggle = ({ mobile }: MobileMenuToggleProps) => {
                             aria-label="GitHub"
                             size="sm"
                             variant="ghost"
-                            color={useColorModeValue("neutral.800", "neutralD.1000")}
+                            color={useColorModeValue("neutral.1000", "neutralD.1000")}
                           >
                             <GithubLogo weight="fill" />
                           </IconButton>
@@ -108,7 +112,7 @@ const MobileMenuToggle = ({ mobile }: MobileMenuToggleProps) => {
                             aria-label="YouTube"
                             size="sm"
                             variant="ghost"
-                            color={useColorModeValue("neutral.800", "neutralD.1000")}
+                            color={useColorModeValue("neutral.1000", "neutralD.1000")}
                           >
                             <YoutubeLogo weight="fill" />
                           </IconButton>

--- a/components/mobile-menu-toggle.tsx
+++ b/components/mobile-menu-toggle.tsx
@@ -73,6 +73,7 @@ const MobileMenuToggle = ({ mobile }: MobileMenuToggleProps) => {
                           <IconButton
                             aria-label="Twitter"
                             size="sm"
+                            variant="ghost"
                             color={useColorModeValue("neutral.800", "neutralD.1000")}
                           >
                             <TwitterLogo weight="fill" />
@@ -82,6 +83,7 @@ const MobileMenuToggle = ({ mobile }: MobileMenuToggleProps) => {
                           <IconButton
                             aria-label="LinkedIn"
                             size="sm"
+                            variant="ghost"
                             color={useColorModeValue("neutral.800", "neutralD.1000")}
                           >
                             <LinkedinLogo weight="fill" />
@@ -91,6 +93,7 @@ const MobileMenuToggle = ({ mobile }: MobileMenuToggleProps) => {
                           <IconButton
                             aria-label="GitHub"
                             size="sm"
+                            variant="ghost"
                             color={useColorModeValue("neutral.800", "neutralD.1000")}
                           >
                             <GithubLogo weight="fill" />
@@ -104,6 +107,7 @@ const MobileMenuToggle = ({ mobile }: MobileMenuToggleProps) => {
                           <IconButton
                             aria-label="YouTube"
                             size="sm"
+                            variant="ghost"
                             color={useColorModeValue("neutral.800", "neutralD.1000")}
                           >
                             <YoutubeLogo weight="fill" />

--- a/components/mobile-navigation.tsx
+++ b/components/mobile-navigation.tsx
@@ -40,7 +40,12 @@ const MobileNavigation = () => {
             href="/blog"
             style={{ width: "100%", display: "flex", justifyContent: "center" }}
           >
-            <MobileMenuButton as="span" label="Blog" icon={<PencilIcon />} px={6} />
+            <MobileMenuButton
+              as="span"
+              label="Blog"
+              icon={<PencilIcon width={20} height={20} />}
+              px={6}
+            />
           </NextLink>
         </Center>
 

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { IconButton } from "@chakra-ui/react";
-import { useColorMode } from "./ui/color-mode";
+import { useColorMode, useColorModeValue } from "./ui/color-mode";
 import { Tooltip } from "@/components/ui/tooltip";
 import { MoonIcon, SunIcon } from "@heroicons/react/24/outline";
 
@@ -12,9 +12,15 @@ interface ThemeToggleProps {
 
 const ThemeToggle = ({ mobile = false }: ThemeToggleProps) => {
   const { colorMode, toggleColorMode } = useColorMode();
+  const iconColor = useColorModeValue("neutral.1100", "neutralD.1100");
 
-  // Pass raw icons so MobileMenuButton can size them like sibling nav icons.
-  const icon = colorMode === "dark" ? <SunIcon /> : <MoonIcon />;
+  // Raw icons with explicit size so mobile nav matches Blog/Menu (~20px).
+  const icon =
+    colorMode === "dark" ? (
+      <SunIcon width={20} height={20} />
+    ) : (
+      <MoonIcon width={20} height={20} />
+    );
 
   return (
     <Tooltip
@@ -32,6 +38,7 @@ const ThemeToggle = ({ mobile = false }: ThemeToggleProps) => {
           variant="ghost"
           borderRadius="full"
           aria-label="Switch theme"
+          color={iconColor}
           onClick={toggleColorMode}
         >
           {icon}

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Icon, IconButton } from "@chakra-ui/react";
+import { IconButton } from "@chakra-ui/react";
 import { useColorMode } from "./ui/color-mode";
 import { Tooltip } from "@/components/ui/tooltip";
 import { MoonIcon, SunIcon } from "@heroicons/react/24/outline";
@@ -13,16 +13,8 @@ interface ThemeToggleProps {
 const ThemeToggle = ({ mobile = false }: ThemeToggleProps) => {
   const { colorMode, toggleColorMode } = useColorMode();
 
-  const icon =
-    colorMode === "dark" ? (
-      <Icon asChild>
-        <SunIcon />
-      </Icon>
-    ) : (
-      <Icon asChild>
-        <MoonIcon />
-      </Icon>
-    );
+  // Pass raw icons so MobileMenuButton can size them like sibling nav icons.
+  const icon = colorMode === "dark" ? <SunIcon /> : <MoonIcon />;
 
   return (
     <Tooltip
@@ -36,7 +28,12 @@ const ThemeToggle = ({ mobile = false }: ThemeToggleProps) => {
           onClick={toggleColorMode}
         />
       ) : (
-        <IconButton borderRadius="full" aria-label="Switch theme" onClick={toggleColorMode}>
+        <IconButton
+          variant="ghost"
+          borderRadius="full"
+          aria-label="Switch theme"
+          onClick={toggleColorMode}
+        >
           {icon}
         </IconButton>
       )}

--- a/lib/notion/api.ts
+++ b/lib/notion/api.ts
@@ -141,7 +141,7 @@ export const getBlogPosts = async ({
 
 export const getPageByPageId = async (pageId: string): Promise<NotionRecordMap | null> => {
   try {
-    const recordMap = (await notionPrivateAPI.getPage(pageId, {})) as NotionRecordMap;
+    const recordMap = (await notionPrivateAPI.getPage(pageId)) as NotionRecordMap;
     const normalizedBlock = Object.fromEntries(
       Object.entries(recordMap?.block ?? {}).map(([blockId, block]) => {
         const typedBlock = block as WrappedNotionBlock | undefined;

--- a/lib/notion/client.ts
+++ b/lib/notion/client.ts
@@ -1,7 +1,14 @@
 import { Client } from "@notionhq/client";
 import { NotionAPI } from "notion-client";
+import { NotionCompatAPI } from "notion-compat";
 
 import { notionKey } from "@/lib/notion/config";
 
-export const notionPrivateAPI = new NotionAPI();
 export const notionAPI = new Client({ auth: notionKey });
+
+// The unofficial notion-client scraper now 403s on page fetches in production.
+// Prefer the official API through notion-compat whenever a token is available so
+// blog/article pages can resolve again after deploy.
+export const notionPrivateAPI = notionKey
+  ? new NotionCompatAPI(notionAPI)
+  : new NotionAPI();

--- a/lib/notion/config.ts
+++ b/lib/notion/config.ts
@@ -3,8 +3,10 @@ export const rootNotionSpaceId = "fde5ac74-eea3-4527-8f00-4482710e1af3";
 
 export const previewImagesEnabled = false;
 
-export const useOfficialNotionAPI =
-  false || (process.env.USE_OFFICIAL_NOTION_API === "true" && Boolean(process.env.NOTION_TOKEN));
+// Prefer the official Notion API whenever a token is present. The unofficial
+// notion-client scraper currently returns 403 for page content fetches, which
+// caused /blog/[slug] to render the 404 page after redeploy.
+export const useOfficialNotionAPI = Boolean(process.env.NOTION_TOKEN);
 
 export const isDev = process.env.NODE_ENV === "development" || !process.env.NODE_ENV;
 

--- a/lib/notion/notion.ts
+++ b/lib/notion/notion.ts
@@ -8,12 +8,6 @@ const notion = useOfficialNotionAPI
   ? new NotionCompatAPI(new Client({ auth: process.env.NOTION_TOKEN }))
   : new NotionAPI();
 
-if (useOfficialNotionAPI) {
-  console.warn(
-    "Using the official Notion API. Note that many blocks only include partial support for formatting and layout. Use at your own risk.",
-  );
-}
-
 export async function getPage(pageId: string) {
   const recordMap = await notion.getPage(pageId);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Production broke after the Chakra UI v3 / pizza calculator deploy (`1517559`). This PR fixes the soft blog 404s, inverted IconButton tokens, oversized mobile theme icon, Lists nav contrast, and updates Daniel’s title to **Senior Design Engineer** sitewide.

### 1) Blog soft 404s
`generateMetadata` succeeded from the official Notion DB query, but page render used unofficial `notion-client` (403) → `notFound()` with HTTP 200. Switched page fetches to `notion-compat` / official API.

### 2) IconButton inverted backgrounds (+ Lists)
Chakra v3 default `variant="solid"`. Set IconButtons and Lists to `ghost` with readable fg tokens; stronger footer icon colors.

### 3) Mobile theme moon/sun size
Force SVG `width`/`height` 20px in `MobileMenuButton` so theme icons match Blog/Menu.

### 4) Title → Senior Design Engineer
- Homepage intro: Senior Design Engineer at Giving What We Can, Netherlands
- Site + home/about SEO descriptions
- RSS channel description
- Article JSON-LD `jobTitle` / `worksFor`

## Test plan
- [x] Soft-404 slugs render articles
- [x] IconButtons / Lists / mobile icons
- [ ] Homepage + metadata show Senior Design Engineer after deploy
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-199029d8-b77f-43ec-b6f8-057914a5708a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-199029d8-b77f-43ec-b6f8-057914a5708a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

