### PR TITLE
Update title to Senior Design Engineer

### DIFF
--- a/components/blog-article-json-ld.tsx
+++ b/components/blog-article-json-ld.tsx
@@ -24,7 +24,16 @@ export default function BlogArticleJsonLd({
     image: socialImage ? [socialImage] : [],
     datePublished: date,
     dateModified: date,
-    author: { "@type": "Person", name: "Daniel Wirtz" },
+    author: {
+      "@type": "Person",
+      name: "Daniel Wirtz",
+      jobTitle: "Senior Design Engineer",
+      worksFor: {
+        "@type": "Organization",
+        name: "Giving What We Can",
+        url: "https://www.givingwhatwecan.org/",
+      },
+    },
     publisher: {
       "@type": "Organization",
       name: "Daniel Wirtz",

--- a/components/route-content/home-page.tsx
+++ b/components/route-content/home-page.tsx
@@ -78,7 +78,7 @@ export default function HomePage({ posts }: HomePageProps) {
               </Link>
             </HStack>
             <Text fontSize={["lg", "2xl"]}>
-              I&apos;m Daniel. I work in the Growth team at{" "}
+              I&apos;m Daniel. I&apos;m a Senior Design Engineer at{" "}
               <Link href="https://www.givingwhatwecan.org/" isExternal>
                 Giving What We Can
               </Link>

--- a/lib/page-metadata.ts
+++ b/lib/page-metadata.ts
@@ -5,14 +5,14 @@ const base = "https://danielwirtz.com";
 export const homeMetadata: Metadata = {
   title: "Home",
   description:
-    "Daniel Wirtz — designer and growth. Latest posts, books, bookmarks, and articles from the Netherlands.",
+    "Daniel Wirtz — Senior Design Engineer at Giving What We Can. Latest posts, books, bookmarks, and articles from the Netherlands.",
   alternates: { canonical: base },
 };
 
 export const aboutMetadata: Metadata = {
   title: "About",
   description:
-    "About Daniel Wirtz: experience, what I like (and dislike), and how this site is built.",
+    "About Daniel Wirtz, Senior Design Engineer at Giving What We Can: experience, what I like (and dislike), and how this site is built.",
   alternates: { canonical: `${base}/about` },
 };
 

--- a/lib/rss.ts
+++ b/lib/rss.ts
@@ -33,7 +33,7 @@ const generateRss = (posts: AirtableRecord<RssPostFields>[]) => {
     <channel>
       <title>Blog - Daniel Wirtz</title>
       <link>https://danielwirtz.com/blog</link>
-      <description>Designer, developer and maker of things.</description>
+      <description>Senior Design Engineer at Giving What We Can.</description>
       <language>en</language>
       <lastBuildDate>${new Date(latestPublishDate).toUTCString()}</lastBuildDate>
       <atom:link href="https://danielwirtz.com/rss.xml" rel="self" type="application/rss+xml"/>

--- a/lib/site-metadata.ts
+++ b/lib/site-metadata.ts
@@ -1,7 +1,8 @@
 import type { Metadata } from "next";
 
 const siteTitle = "Daniel Wirtz";
-const siteDescription = "Designer, tech enthusiast and entrepreneur of sorts";
+const siteDescription =
+  "Senior Design Engineer at Giving What We Can, based in the Netherlands.";
 
 export const siteMetadata: Metadata = {
   title: { default: siteTitle, template: "%s – Daniel Wirtz" },

--- a/public/rss.xml
+++ b/public/rss.xml
@@ -3,7 +3,7 @@
     <channel>
       <title>Blog - Daniel Wirtz</title>
       <link>https://danielwirtz.com/blog</link>
-      <description>Designer, developer and maker of things.</description>
+      <description>Senior Design Engineer at Giving What We Can.</description>
       <language>en</language>
       <lastBuildDate>Thu, 09 Dec 2021 19:35:00 GMT</lastBuildDate>
       <atom:link href="https://danielwirtz.com/rss.xml" rel="self" type="application/rss+xml"/>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #37 (merged before this commit could ship). Updates Daniel’s title to **Senior Design Engineer** everywhere it was still using Growth-team / designer wording.

### Changes
- Homepage intro: Senior Design Engineer at Giving What We Can, Netherlands
- Site + home/about SEO descriptions
- RSS channel description
- Article JSON-LD `jobTitle` / `worksFor`

No bug-fix changes — those already landed in #37.

## Test plan
- [ ] Homepage intro shows Senior Design Engineer at Giving What We Can
- [ ] View source / meta description reflects the new title
- [ ] Blog article JSON-LD includes `jobTitle` and `worksFor`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-199029d8-b77f-43ec-b6f8-057914a5708a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-199029d8-b77f-43ec-b6f8-057914a5708a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

